### PR TITLE
fix double-tap to change camera, add apple's PWA functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Fork of [alexfromapex's](https://github.com/alexfromapex/camera-viewer) repository.
+
 This simple HTML video app allows you to use your iOS camera as a video source that covers the entire screen, without being obstructed by any camera controls.  This is the perfect solution for recording from your MacBook with QuickTime, while using your iPhone as the camera source.
 
 #### Usage

--- a/README.md
+++ b/README.md
@@ -3,10 +3,14 @@ Fork of [alexfromapex's](https://github.com/alexfromapex/camera-viewer) reposito
 This simple HTML video app allows you to use your iOS camera as a video source that covers the entire screen, without being obstructed by any camera controls.  This is the perfect solution for recording from your MacBook with QuickTime, while using your iPhone as the camera source.
 
 #### Usage
-Go to this address on your iPhone: https://alexfromapex.github.io/camera-viewer/
+Go to this address on your iOS Device: https://trevcan.github.io/camera-viewer/
 
 Pinch zoom in/out on iPhone until video fits to screen.  Double tap on the video to switch between cameras (i.e. front/back).
 
-**Only tested with iPhone X (iOS 13.2.1) and MacOS 10.14.6+ (Mojave)**
+**Tested with:**
+- iPhone 6S (iOS 14.3)
+- iPad Mini 4th gen (iPadOS 14.6)
+- iPhone X (iOS 13.2.1)
+- MacOS 10.14.6+ (Mojave)
 
 ![](https://user-images.githubusercontent.com/1907805/66277697-18b4e400-e870-11e9-9dd2-f79669c41951.png)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 Fork of [alexfromapex's](https://github.com/alexfromapex/camera-viewer) repository.
 
-This simple HTML video app allows you to use your iOS camera as a video source that covers the entire screen, without being obstructed by any camera controls.  This is the perfect solution for recording from your MacBook with QuickTime, while using your iPhone as the camera source.
+This simple HTML video app allows you to use your iOS camera as a video source that covers the entire screen, without being obstructed by any camera controls.  This is the perfect solution for recording from your MacBook with QuickTime, while using your iPhone as the camera source. Conveniently, it works completely as a static website and is also a PWA which can be added to an iOS' home screen device, therefore able to run without an internet connection.
 
 #### Usage
-Go to this address on your iOS Device: https://trevcan.github.io/camera-viewer/
+1. Go to this web address on your iOS Device: https://trevcan.github.io/camera-viewer/
+2. Pinch zoom in/out on iPhone until video fits to screen.  tap fast on the video to switch between cameras (i.e. front/back).
 
-Pinch zoom in/out on iPhone until video fits to screen.  Double tap on the video to switch between cameras (i.e. front/back).
+## Suggested usage
+- this web app may be useful when using it as a virtual camera, e.g. with [RPiPlay](https://github.com/FD-/RPiPlay) in other words, allowing you to transmitt your _raw-camera_ from your iOS Device to your computer/PC, raspberry and use it as a virtual camera with [OBS](https://obsproject.com/). 
 
 **Tested with:**
 - iPhone 6S (iOS 14.3)

--- a/index.html
+++ b/index.html
@@ -1,7 +1,10 @@
 <!doctype html>
 <html lang="en">
 <head>
-	<meta charset="utf-8" />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="viewport-fit=cover, width=device-width" />
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 	<title>Camera Viewer</title>
 <script src="./view-camera.js" type="text/javascript"></script>
 <link rel="stylesheet" type="text/css" href="./view-camera.css" />


### PR DESCRIPTION
- fixes double-tap to change camera (thanks to @matthewdfleming for providing [this patch](https://github.com/alexfromapex/camera-viewer/issues/1)
- add PWA functionality (thanks to @EricAndrechek for providing [this PR](https://github.com/alexfromapex/camera-viewer/pull/4). If you don't know what an iOS Progressive Web App it basically allows you to save it to your home screen to use the app offline! No need to have an internet connection, just works!
